### PR TITLE
Optional .deploy extension

### DIFF
--- a/updateClickOnce/Update-ClickOnce.ps1
+++ b/updateClickOnce/Update-ClickOnce.ps1
@@ -48,12 +48,16 @@ $binaryFolder = Rename-BinariesFolder $binaryFolder $Version
 $appManifestPath = "$binaryFolder\$appName.exe.manifest"
 
 # Remove .deploy extensions
-Update-DeployExtensions $binaryFolder -RemoveExtension
+if ($ReplaceDeploy) {
+    Update-DeployExtensions $binaryFolder -RemoveExtension
+}
 
 # Sign package
 Update-ClickOnce -mageFolder:$mageFolder -appManifest:$appManifestPath -packageManifest:$packageManifestPath -manifestName:$appName -applicationName:$ApplicationName -version:$Version -certFile:$Certificate -certPwd:$CertificatePassword -publisher:$Publisher -providerUrl:$ProviderUrl -minVersion:$MinVersion -advanced:$Advanced
 
 # Add .deploy extensions
-Update-DeployExtensions $binaryFolder
+if ($ReplaceDeploy) {
+    Update-DeployExtensions $binaryFolder
+}
 
 ## tfx extension create --manifest-globs vss-extension.json --rev-version

--- a/updateClickOnce/task.json
+++ b/updateClickOnce/task.json
@@ -95,7 +95,7 @@
         "name": "ReplaceDeploy",
         "type": "bool",
         "label": "Replace Deploy File Extension",
-        "defaultValue": false,
+        "defaultValue": true,
         "required": true,
         "helpMarkDown": "Select this if the msbuild publish step produces .deploy files."
       },

--- a/updateClickOnce/task.json
+++ b/updateClickOnce/task.json
@@ -92,6 +92,14 @@
         "helpMarkDown": "The minimum version of this application a user can run. This flag makes the named version of your application a required update, use %version% to use the current version as minimum. The argument must be a valid version string of the format N.N.N.N"
       },
       { 
+        "name": "ReplaceDeploy",
+        "type": "bool",
+        "label": "Replace Deploy File Extension",
+        "defaultValue": false,
+        "required": true,
+        "helpMarkDown": "Select this if the msbuild publish step produces .deploy files."
+      },
+      { 
           "name": "Advanced", 
           "type": "multiLine", 
           "label": "Advanced XML modification", 


### PR DESCRIPTION
Some clickonce publish folders do not use .deploy file extension. Adding .deploy breaks the app.